### PR TITLE
Fix dependency on lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,13 @@
     "grunttask",
     "watch"
   ],
-  "dependencies": [],
+  "dependencies": {
+    "lodash": "~4.17.4"
+  },
   "devDependencies": {
     "grunt": "~1.0.1",
     "grunt-contrib-jshint": "~1.1.0",
     "grunt-contrib-nodeunit": "~1.0.0",
-    "grunt-contrib-watch": "~1.0.0",
-    "lodash": "~4.17.4"
+    "grunt-contrib-watch": "~1.0.0"
   }
 }


### PR DESCRIPTION
`lodash` is a real dependency, not a dev dependency.

As it is, I can't use `grunt-simple-watch-legacy` with npm v2, as it doesn't install the `lodash` dependency:
```
Registering "grunt-simple-watch-legacy" local Npm module tasks.
Reading MYPROJECT/node_modules/grunt-simple-watch-legacy/package.json...OK
Parsing MYPROJECT/node_modules/grunt-simple-watch-legacy/package.json...OK
Loading "simple_watch.js" tasks...ERROR
>> Error: Cannot find module 'lodash'
>>   at Function.Module._resolveFilename (module.js:325:15)
>>   at Function.Module._load (module.js:276:25)
>>   at Module.require (module.js:353:17)
>>   at require (internal/module.js:12:17)
>>   at Object.module.exports (MYPROJECT/node_modules/grunt-simple-watch-legacy/tasks/simple_watch.js:26:10)
>>   at loadTask (MYPROJECT/node_modules/grunt/lib/grunt/task.js:318:10)
>>   at MYPROJECT/node_modules/grunt/lib/grunt/task.js:354:7
>>   at Array.forEach (native)
>>   at loadTasks (MYPROJECT/node_modules/grunt/lib/grunt/task.js:353:11)
>>   at Task.task.loadNpmTasks (MYPROJECT/node_modules/grunt/lib/grunt/task.js:401:5)
>>   at MYPROJECT/node_modules/load-grunt-tasks/index.js:34:10
>>   at Array.forEach (native)
>>   at module.exports (MYPROJECT/node_modules/load-grunt-tasks/index.js:26:29)
>>   at Object.module.exports (MYPROJECT/Gruntfile.js:19:30)
>>   at loadTask (MYPROJECT/node_modules/grunt/lib/grunt/task.js:318:10)
>>   at Task.task.init (MYPROJECT/node_modules/grunt/lib/grunt/task.js:437:5)
>>   at Object.grunt.tasks (MYPROJECT/node_modules/grunt/lib/grunt.js:111:8)
>>   at Object.module.exports [as cli] (MYPROJECT/node_modules/grunt/lib/grunt/cli.js:27:9)
>>   at Object.<anonymous> (NVM_ROOT/v4.8.4/node_modules/grunt-cli/bin/grunt:44:20)
>>   at Module._compile (module.js:409:26)
>>   at Object.Module._extensions..js (module.js:416:10)
>>   at Module.load (module.js:343:32)
>>   at Function.Module._load (module.js:300:12)
>>   at Function.Module.runMain (module.js:441:10)
>>   at startup (node.js:140:18)
>>   at node.js:1043:3
```